### PR TITLE
Make ntEdit+Sealer compatible with newer ntHits/ntEdit versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An automated protocol for finishing long-read genome assemblies using short read
 
 - GNU Make
 - Python 3
-- [ntHits](https://github.com/bcgsc/nthits) v0.0.1
+- [ntHits](https://github.com/bcgsc/nthits) v0.0.1+
 - [ntEdit](https://github.com/bcgsc/ntEdit) v1.3.5+
 - [ABySS](https://github.com/bcgsc/abyss) v2.3.2+ (includes Sealer and ABySS-Bloom)
 
@@ -19,7 +19,7 @@ An automated protocol for finishing long-read genome assemblies using short read
 The ntEdit+Sealer dependencies are available from [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html):
 
 ```bash
-conda install -c bioconda nthits=0.0.1 ntedit abyss
+conda install -c bioconda nthits ntedit abyss
 ```
 
 All dependencies are also available from [Homebrew](https://docs.brew.sh/Installation):

--- a/ntedit-sealer
+++ b/ntedit-sealer
@@ -95,9 +95,19 @@ ntedit: nthits $(seqs_basename).ntedit_edited.fa
 ntedit_sealer: abyss_bloom $(seqs_basename).ntedit_edited.prepd.sealer_scaffold.fa
 
 # Create bloom filters
+
+# ntCard - only needed for ntHits v1.0.0+
+ntcard_hist_k%.hist: $(reads)
+	$(log_time) ntcard -k$* -t$t -p ntcard_hist $(reads)
+
 # ntEdit BFs
+ifeq ($(shell nthits --version 2>&1 |grep "0.1.0"),) # Indicates ntHits v1.0.0+
+sr_solid_k%.bf: ntcard_hist_k%.hist $(reads)
+	$(log_time) nthits bf -f $< --solid -t $t -k $* -o sr_solid_k$* $(reads)
+else
 sr_solid_k%.bf: $(reads)
 	$(log_time) nthits -b36 --outbloom --solid -p sr_solid -k$* -t$t $(reads)
+endif
 
 # Sealer BFs
 k%.bloom.z: $(reads)

--- a/ntedit-sealer
+++ b/ntedit-sealer
@@ -103,7 +103,7 @@ ntcard_hist_k%.hist: $(reads)
 # ntEdit BFs
 ifeq ($(shell nthits --version 2>&1 |grep "0.1.0"),) # Indicates ntHits v1.0.0+
 sr_solid_k%.bf: ntcard_hist_k%.hist $(reads)
-	$(log_time) nthits bf -f $< --solid -t $t -k $* -o sr_solid_k$* $(reads)
+	$(log_time) nthits bf -f $< --solid -t $t -k $* -o sr_solid_k$*.bf $(reads)
 else
 sr_solid_k%.bf: $(reads)
 	$(log_time) nthits -b36 --outbloom --solid -p sr_solid -k$* -t$t $(reads)


### PR DESCRIPTION
* Add logic to make ntedit+sealer compatible with ntHits v1.0.0+ (and thus ntEdit v2.0.0+)
  * The pipeline is still backwards compatible, so it run the commands as before if ntHits v0.0.1 is detected
* Note that we are checking for the string '0.1.0' when checking the ntHits version - erroneously, the v0.0.1 ntHits release prints out v0.1.0 with `--version`
* Tested using the dataset used in the Current Protocols manuscript
 
Dry-run with ntHits v0.0.1 installed:
```
(python3.8) [lcoombe@hpce706 re-run]$ ntedit-sealer finish seqs=ecoli_shasta.fa reads="SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz" k="80 65 50" b=200M  -nB
abyss-bloom build -v -v -k80 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k80.bloom.z
abyss-bloom build -v -v -k65 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k65.bloom.z
abyss-bloom build -v -v -k50 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k50.bloom.z
nthits -b36 --outbloom --solid -p sr_solid -k80 -t8 SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
nthits -b36 --outbloom --solid -p sr_solid -k65 -t8 SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
nthits -b36 --outbloom --solid -p sr_solid -k50 -t8 SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
/projects/btl/lcoombe/git/ntedit_sealer_protocol/bin/run_ntedit.sh ecoli_shasta "sr_solid_k80.bf sr_solid_k65.bf sr_solid_k50.bf" "80 65 50" 0.5 0.5 8 ecoli_shasta.ntedit_edited.fa
python3 /projects/btl/lcoombe/git/ntedit_sealer_protocol/bin/mask_short_sequences.py -s -k50 ecoli_shasta.ntedit_edited.fa > ecoli_shasta.ntedit_edited.prepd.fa
abyss-sealer -v -S ecoli_shasta.ntedit_edited.prepd.fa -t ecoli_shasta.ntedit_edited.prepd-sealed-trace.txt \
-o ecoli_shasta.ntedit_edited.prepd.sealer -L100 -j8 -P10 --lower \
-k80 --input-bloom=<(pigz -p8 -d -c k80.bloom.z) -k65 --input-bloom=<(pigz -p8 -d -c k65.bloom.z) -k50 --input-bloom=<(pigz -p8 -d -c k50.bloom.z)
echo "ntEdit and Sealer polishing steps complete! Polished assembly can be found in: ecoli_shasta.ntedit_edited.prepd.sealer_scaffold.fa"
```

Dry-run with ntHits v1.0.3 installed:
```
(ntedit_sealer_test) [lcoombe@hpce706 re-run]$ ntedit-sealer finish seqs=ecoli_shasta.fa reads="SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz" k="80 65 50" b=200M  -nB
abyss-bloom build -v -v -k80 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k80.bloom.z
abyss-bloom build -v -v -k65 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k65.bloom.z
abyss-bloom build -v -v -k50 -j8 -b200M -l2 -q15 - SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz | pigz -p8 -c > k50.bloom.z
ntcard -k80 -t8 -p ntcard_hist SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
nthits bf -f ntcard_hist_k80.hist --solid -t 8 -k 80 -o sr_solid_k80.bf SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
ntcard -k65 -t8 -p ntcard_hist SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
nthits bf -f ntcard_hist_k65.hist --solid -t 8 -k 65 -o sr_solid_k65.bf SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
ntcard -k50 -t8 -p ntcard_hist SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
nthits bf -f ntcard_hist_k50.hist --solid -t 8 -k 50 -o sr_solid_k50.bf SRR15859208_1.fastq.gz SRR15859208_2.fastq.gz
/projects/btl/lcoombe/git/ntedit_sealer_protocol/bin/run_ntedit.sh ecoli_shasta "sr_solid_k80.bf sr_solid_k65.bf sr_solid_k50.bf" "80 65 50" 0.5 0.5 8 ecoli_shasta.ntedit_edited.fa
python3 /projects/btl/lcoombe/git/ntedit_sealer_protocol/bin/mask_short_sequences.py -s -k50 ecoli_shasta.ntedit_edited.fa > ecoli_shasta.ntedit_edited.prepd.fa
abyss-sealer -v -S ecoli_shasta.ntedit_edited.prepd.fa -t ecoli_shasta.ntedit_edited.prepd-sealed-trace.txt \
-o ecoli_shasta.ntedit_edited.prepd.sealer -L100 -j8 -P10 --lower \
-k80 --input-bloom=<(pigz -p8 -d -c k80.bloom.z) -k65 --input-bloom=<(pigz -p8 -d -c k65.bloom.z) -k50 --input-bloom=<(pigz -p8 -d -c k50.bloom.z)
echo "ntEdit and Sealer polishing steps complete! Polished assembly can be found in: ecoli_shasta.ntedit_edited.prepd.sealer_scaffold.fa"
```